### PR TITLE
fix: option java_generate_equals_and_hash = true bug

### DIFF
--- a/proto/ClientDatanodeProtocol.proto
+++ b/proto/ClientDatanodeProtocol.proto
@@ -28,7 +28,7 @@
 option java_package = "org.apache.hadoop.hdfs.protocol.proto";
 option java_outer_classname = "ClientDatanodeProtocolProtos";
 option java_generic_services = true;
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.hdfs;
 
 import "Security.proto";

--- a/proto/ClientNamenodeProtocol.proto
+++ b/proto/ClientNamenodeProtocol.proto
@@ -25,7 +25,7 @@
 option java_package = "org.apache.hadoop.hdfs.protocol.proto";
 option java_outer_classname = "ClientNamenodeProtocolProtos";
 option java_generic_services = true;
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.hdfs;
 
 import "Security.proto";

--- a/proto/IpcConnectionContext.proto
+++ b/proto/IpcConnectionContext.proto
@@ -24,7 +24,7 @@
 
 option java_package = "org.apache.hadoop.ipc.protobuf";
 option java_outer_classname = "IpcConnectionContextProtos";
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.common;
 
 /**

--- a/proto/ProtobufRpcEngine.proto
+++ b/proto/ProtobufRpcEngine.proto
@@ -30,7 +30,7 @@
  */
 option java_package = "org.apache.hadoop.ipc.protobuf";
 option java_outer_classname = "ProtobufRpcEngineProtos";
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.common;
 
 /**

--- a/proto/RpcHeader.proto
+++ b/proto/RpcHeader.proto
@@ -24,7 +24,7 @@
 
 option java_package = "org.apache.hadoop.ipc.protobuf";
 option java_outer_classname = "RpcHeaderProtos";
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.common;
 
 /**

--- a/proto/Security.proto
+++ b/proto/Security.proto
@@ -25,7 +25,7 @@
 option java_package = "org.apache.hadoop.security.proto";
 option java_outer_classname = "SecurityProtos";
 option java_generic_services = true;
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.common;
 
 /**

--- a/proto/acl.proto
+++ b/proto/acl.proto
@@ -18,7 +18,7 @@
 
 option java_package = "org.apache.hadoop.hdfs.protocol.proto";
 option java_outer_classname = "AclProtos";
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.hdfs;
 
 import "hdfs.proto";

--- a/proto/datatransfer.proto
+++ b/proto/datatransfer.proto
@@ -27,7 +27,7 @@
 
 option java_package = "org.apache.hadoop.hdfs.protocol.proto";
 option java_outer_classname = "DataTransferProtos";
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.hdfs;
 
 import "Security.proto";

--- a/proto/hdfs.proto
+++ b/proto/hdfs.proto
@@ -28,7 +28,7 @@
 
 option java_package = "org.apache.hadoop.hdfs.protocol.proto";
 option java_outer_classname = "HdfsProtos";
-option java_generate_equals_and_hash = true;
+//option java_generate_equals_and_hash = true;
 package hadoop.hdfs;
 
 import "Security.proto";


### PR DESCRIPTION
remove all proto files content: option java_generate_equals_and_hash = true;
 to solve centos 6.3  compatiable bug with lower version protobuf-c  compiler;