### PR TITLE
probably not a final solution or anything, but this'll help people be able to compile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build/proto: proto/*.proto build
 	$(UNCRUSTIFY) proto/*.[ch]
 	touch build/proto
 
-CCFLAGS := $(shell pkg-config --cflags --libs fuse libprotobuf-c) -Werror -Wall -Wextra -I. -std=gnu99
+CCFLAGS := $(shell pkg-config --cflags --libs fuse libprotobuf-c) -Werror -Wall -Wextra -I. -std=gnu99 -Wno-unused
 
 build/native-hdfs-fuse: src/*.c src/*.h build/proto build
 	mkdir -p build

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Unlike [other FUSE HDFS implementations](https://wiki.apache.org/hadoop/Mountabl
 
     make && make install
 
-This will compile and install the <tt>native-hdfs-fuse</tt> binary to <tt>/usr/bin</tt>. The build process needs the [protoc-c](https://github.com/protobuf-c/protobuf-c) protobuf compiler available and uses [pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config) to find the <tt>fuse</tt> and <tt>libprotobuf-c</tt> shared libraries it needs to link to.
+This will compile and install the <tt>native-hdfs-fuse</tt> binary to <tt>/usr/bin</tt>. The build process needs the [protoc-c](https://github.com/protobuf-c/protobuf-c) protobuf compiler available and uses [pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config) to find the <tt>fuse</tt> and <tt>libprotobuf-c</tt> shared libraries it needs to link to. Additionally, [uncrustify](https://github.com/uncrustify/uncrustify) version 0.60 or higher is required.
 
 You can make a debug build using <tt>make debug</tt>; this adds debug symbols to the binary and compiles in verbose logging statements.
 


### PR DESCRIPTION
added -Wno-unused to the compiler flags to make this successfully compile, and documented the uncrustify dependency.
