### PR TITLE
Added dependencies for Ubuntu 22.04 and missing flag for compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build/proto: proto/*.proto build
 	$(UNCRUSTIFY) proto/*.[ch]
 	touch build/proto
 
-CCFLAGS := $(shell pkg-config --cflags --libs fuse libprotobuf-c) -Werror -Wall -Wextra -I. -std=gnu99
+CCFLAGS := $(shell pkg-config --cflags --libs fuse libprotobuf-c) -Werror -Wall -Wextra -I. -std=gnu99 -Wno-unused
 
 build/native-hdfs-fuse: src/*.c src/*.h build/proto build
 	mkdir -p build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,20 @@ Unlike [other FUSE HDFS implementations](https://wiki.apache.org/hadoop/Mountabl
 
 ### Compiling
 
-    make && make install
+<details closed>
+<summary>Dependencies for Ubuntu (22.04)</summary>
+
+```bash
+sudo apt-get install -y pkgconf libfuse-dev libprotobuf-c-dev libprotobuf-dev protobuf-c-compiler uncrustify
+```
+
+</details>
+
+Compile the program :
+
+```sh
+make && make install
+```
 
 This will compile and install the <tt>native-hdfs-fuse</tt> binary to <tt>/usr/bin</tt>. The build process needs the [protoc-c](https://github.com/protobuf-c/protobuf-c) protobuf compiler available and uses [pkg-config](http://www.freedesktop.org/wiki/Software/pkg-config) to find the <tt>fuse</tt> and <tt>libprotobuf-c</tt> shared libraries it needs to link to.
 
@@ -16,7 +29,9 @@ You can make a debug build using <tt>make debug</tt>; this adds debug symbols to
 
 ### Running
 
-    native-hdfs-fuse <namenode host> <namenode port, usually 8020> <other FUSE arguments, including mount directory>
+```sh
+native-hdfs-fuse <namenode host> <namenode port, usually 8020> <other FUSE arguments, including mount directory>
+```
 
 ## Testing
 

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -717,7 +717,7 @@ align_with_tabs                          = false    # false/true
 align_on_tabstop                         = false    # false/true
 
 # Whether to left-align numbers
-align_number_left                        = false    # false/true
+# align_number_left                        = false    # false/true
 
 # Align variable definitions in prototypes and functions
 align_func_params                        = false    # false/true


### PR DESCRIPTION
I've added dependencies required by this project to be compiled and run on Ubuntu 22.04 as well as the missing flag which makes the project compilable (thank you @cg- #11). This includes a fix about the uncrustify library as well (c.f: #13).